### PR TITLE
Import external libraries with CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,4 +19,4 @@ matrix:
     - php: 7.1
 
 script:
-- curl -sSL https://raw.githubusercontent.com/AOEpeople/MageTestStand/master/setup.sh | bash
+- curl -sSL https://raw.githubusercontent.com/gpaddis/MageTestStand/install-module-dependencies/setup.sh | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ php:
   - 7.1
 
 env:
-  - MAGENTO_VERSION="magento-mirror-1.9.3.4"
+  - MAGENTO_VERSION="magento-mirror-1.9.3.10"
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,18 +6,19 @@ sudo: false
 dist: precise
 
 php:
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
 
 env:
   - MAGENTO_VERSION="magento-mirror-1.9.3.4"
-  - INSTALL_DEPENDENCIES=1
 
 matrix:
   allow_failures:
     - php: 7.1
+
+before_script:
+  - export INSTALL_DEPENDENCIES=1
 
 script:
 - curl -sSL https://raw.githubusercontent.com/gpaddis/MageTestStand/install-module-dependencies/setup.sh | bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
 
 env:
   - MAGENTO_VERSION="magento-mirror-1.9.3.4"
+  - INSTALL_DEPENDENCIES=1
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,4 +21,4 @@ before_script:
   - export INSTALL_DEPENDENCIES=1
 
 script:
-- curl -sSL https://raw.githubusercontent.com/gpaddis/MageTestStand/install-module-dependencies/setup.sh | bash
+- curl -sSL https://raw.githubusercontent.com/gpaddis/MageTestStand/master/setup.sh | bash

--- a/app/code/local/Namespace/ModuleName/Model/Foo.php
+++ b/app/code/local/Namespace/ModuleName/Model/Foo.php
@@ -1,10 +1,15 @@
 <?php
 
+use Carbon\Carbon;
+
 /**
  * @package    Namespace_ModuleName
  * @author     authorName <author@email.net>
  */
 class Namespace_ModuleName_Model_Foo extends Mage_Core_Model_Abstract
 {
-    // Code...
+    public function getCurrentDatetime()
+    {
+        return Carbon::now();
+    }
 }

--- a/app/code/local/Namespace/ModuleName/Model/Foo.php
+++ b/app/code/local/Namespace/ModuleName/Model/Foo.php
@@ -8,8 +8,8 @@ use Carbon\Carbon;
  */
 class Namespace_ModuleName_Model_Foo extends Mage_Core_Model_Abstract
 {
-    public function getCurrentDatetime()
+    public function getCurrentDate()
     {
-        return Carbon::now();
+        return Carbon::now()->toDateString();
     }
 }

--- a/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
+++ b/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
@@ -1,5 +1,7 @@
 <?php
 
+use Carbon\Carbon;
+
 /**
  * @package    Namespace_ModuleName
  * @author     authorName <author@email.net>
@@ -15,5 +17,12 @@ class Namespace_ModuleName_Test_Model_Foo extends EcomDev_PHPUnit_Test_Case
     public function exampleTest()
     {
         $this->assertTrue(true);
+    }
+
+    public function testItReturnsTheCurrentDateTime()
+    {
+        $foo = Mage::getModel('namespace_modulename/foo');
+        $now = Carbon::now();
+        $this->assertEquals($now, $foo->getCurrentDatetime());
     }
 }

--- a/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
+++ b/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
@@ -13,13 +13,13 @@ class Namespace_ModuleName_Test_Model_Foo extends EcomDev_PHPUnit_Test_Case
 {
     /**
      * @test
+     *
+     * The test checks much more than just the current date: the module Foo imports
+     * the Carbon library thanks to the module firegento/psr0autoloader, and the
+     * forked testing module MageTestStand installs the dependencies during the
+     * build process, so that they are available when the test is run.
      */
-    public function exampleTest()
-    {
-        $this->assertTrue(true);
-    }
-
-    public function testItReturnsTheCurrentDate()
+    public function it_returns_the_current_date()
     {
         $foo = Mage::getModel('namespace_modulename/foo');
         $today = Carbon::now()->toDateString();

--- a/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
+++ b/app/code/local/Namespace/ModuleName/Test/Model/Foo.php
@@ -19,10 +19,10 @@ class Namespace_ModuleName_Test_Model_Foo extends EcomDev_PHPUnit_Test_Case
         $this->assertTrue(true);
     }
 
-    public function testItReturnsTheCurrentDateTime()
+    public function testItReturnsTheCurrentDate()
     {
         $foo = Mage::getModel('namespace_modulename/foo');
-        $now = Carbon::now();
-        $this->assertEquals($now, $foo->getCurrentDatetime());
+        $today = Carbon::now()->toDateString();
+        $this->assertEquals($today, $foo->getCurrentDate());
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
     },
 
     "require-dev": {
-        "ecomdev/ecomdev_phpunit": "*"
+        "ecomdev/ecomdev_phpunit": "dev-dev"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     },
 
     "require-dev": {
-        "ecomdev/ecomdev_phpunit": "dev-dev"
+        "ecomdev/ecomdev_phpunit": "dev-dev",
+        "mockery/mockery": "^1.0"
     },
     "extra": {
         "magento-root-dir": "root"

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,5 @@
     "require-dev": {
         "ecomdev/ecomdev_phpunit": "dev-dev",
         "mockery/mockery": "^1.0"
-    },
-    "extra": {
-        "magento-root-dir": "root"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
 
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
+        "firegento/psr0autoloader": "*",
         "nesbot/carbon": "^2.5"
     },
 

--- a/composer.json
+++ b/composer.json
@@ -10,10 +10,14 @@
     ],
 
     "require": {
-        "magento-hackathon/magento-composer-installer": "*"
+        "magento-hackathon/magento-composer-installer": "*",
+        "nesbot/carbon": "^2.5"
     },
 
     "require-dev": {
         "ecomdev/ecomdev_phpunit": "dev-dev"
+    },
+    "extra": {
+        "magento-root-dir": "root"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "magento-hackathon/magento-composer-installer": "*",
         "firegento/psr0autoloader": "*",
-        "nesbot/carbon": "^2.5"
+        "nesbot/carbon": "*"
     },
 
     "require-dev": {


### PR DESCRIPTION
Switch to a forked MageTestStand to allow the installation of external dependencies from the modules's composer.json file.